### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,8 @@ Suggests:
     SummarizedExperiment,
     zinbwave,
     rmarkdown
+Remotes:
+    github::skinnider/dismay
 RdMacros:
     Rdpack
 VignetteBuilder: knitr


### PR DESCRIPTION
The {dismay} package appears to only be available from Github, so for it to be automatically installed as a dependency of {acorde}, it needs to be listed in the "Remotes" section of DESCRIPTION.